### PR TITLE
Try to reconnect to the hpfeeds server if the connection is down

### DIFF
--- a/kippo/dblog/hpfeeds.py
+++ b/kippo/dblog/hpfeeds.py
@@ -101,6 +101,9 @@ class hpclient(object):
 			self.handle_established()
 
 	def send(self, data):
+                if not self.s:
+                        self.connect()
+
 		if not self.s: return
 		self.s.send(data)
 


### PR DESCRIPTION
Do this when we are trying to send data. Without this fix the client will never recover if it fails to 
talk to the server even once. This can happen when the network is not completely initialized when
kippo starts.